### PR TITLE
Bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,16 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.0.1'
-
+    classpath 'com.android.tools.build:gradle:4.2.1'
   }
 }
 
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,14 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 28
-        versionName "0.4.0"
-        versionCode 4
+        minSdkVersion 21
+        targetSdkVersion 30
+        versionName "0.5.0"
+        versionCode 5
 
         proguardFile 'proguard.cfg'
         consumerProguardFiles 'proguard.cfg'
@@ -26,10 +25,10 @@ android {
 }
 
 dependencies {
-    implementation "androidx.annotation:annotation:1.1.0"
-    implementation "androidx.core:core:1.1.0"
+    implementation "androidx.annotation:annotation:1.2.0"
+    implementation "androidx.core:core:1.3.2"
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.squareup.okhttp3:okhttp:3.14.8'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:2.28.2'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,13 +2,12 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion "28.0.3"
+  compileSdkVersion 30
 
   defaultConfig {
     applicationId "de.stocard.placesautocompletedemo"
-    minSdkVersion 14
-    targetSdkVersion 28
+    minSdkVersion 21
+    targetSdkVersion 30
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
- AGP to 4.2.1
- Replace `jcenter` with `mavencentral`
- Bump min sdk to 21, target sdk to 30
- Bump dependencies